### PR TITLE
remove pyflake and update version of pyflakes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ django-bootstrap-form==3.2
 flake8==2.4.1
 mccabe==0.3.1
 pep8==1.5.7
-pyflake==0.1.9
-pyflakes==0.9.2
+pyflakes==1.2.3
 wheel==0.24.0
 wsgiref==0.1.2


### PR DESCRIPTION
pyflake==0.1.9는 pip에서 존재하지 않는 패키지로 인식해 설치에 문제를 일으켜서 삭제했습니다.
하는 김에 pyflakes의 디펜던시 버전을 업그레이드 하였습니다.
